### PR TITLE
repeated patching after Reload UI

### DIFF
--- a/scripts/cli-interruption.py
+++ b/scripts/cli-interruption.py
@@ -1,11 +1,12 @@
 import logging, signal
-from modules import shared
+from modules import shared, script_callbacks
 
 sharedStateLog = logging.getLogger('modules.shared_state')
 if sharedStateLog.getEffectiveLevel() > logging.INFO:
     sharedStateLog.setLevel(logging.INFO)
 
 oldCtrlC = signal.getsignal(signal.SIGINT)
+
 
 def newCtrlC(*args, **kwargs):
     if shared.state.job != "" and not shared.state.interrupted:
@@ -15,4 +16,12 @@ def newCtrlC(*args, **kwargs):
     else:
         oldCtrlC(*args, **kwargs)
 
+
 signal.signal(signal.SIGINT, newCtrlC)
+
+
+def un_patch():
+    signal.signal(signal.SIGINT, oldCtrlC)
+
+
+script_callbacks.on_script_unloaded(un_patch)


### PR DESCRIPTION
fix recursively calling newCtrlC after Reload UI`

if you `Reload UI` as the original interrupt function was already been replaced with your `newCtrlC`
the `oldCtrlC` you got from `signal.getsignal(signal.SIGINT)` it's actually `newCtrlC`

---

to be honest because of how it works it doesn't really break anything but I don't think it's a desirable behavior